### PR TITLE
アイコンくるくるの修正

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,7 @@
 		"semi": [ "error", "always"],
 		"quotes": [ "warn", "single" ],
 		"no-unused-vars": "off",
-		"@typescript-eslint/no-unused-vars": ["error"],
+		"@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_.+" }],
 		"prettier/prettier": [ "error", { "tabWidth": 2, "semi": true, "singleQuote": true, "endOfLine":"auto" } ]
 	}
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -109,7 +109,6 @@ const Social = {
 
 const Home = (): JSX.Element => {
   const [rotate, setRotate] = useState(false);
-  const flipRotation = () => setRotate(!rotate);
   return (
     <Layout>
       <Head>
@@ -119,8 +118,7 @@ const Home = (): JSX.Element => {
         <Avatar
           src={'https://github.com/ekuinox.png'}
           rotate={rotate}
-          onClick={flipRotation}
-          onTouchEnd={flipRotation}
+          onClick={() => setRotate(!rotate)}
         />
         <H1>{'ekuinox | れもくす'}</H1>
         <Social.Ul>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,11 +27,20 @@ const AvatarRotation = keyframes`
   to { transform: rotate(-360deg); }
 `;
 
-const Avatar = styled.img<{ rotate: boolean }>`
+const Avatar = styled(
+  ({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    rotate: _rotate,
+    ...props
+  }: React.DetailedHTMLProps<
+    React.ImgHTMLAttributes<HTMLImageElement>,
+    HTMLImageElement
+  > & { rotate: boolean }) => <img {...props} />
+)`
   height: 150px;
   border-radius: 50%;
-  ${({ rotate }) =>
-    rotate
+  ${(props) =>
+    props.rotate
       ? css`
           animation: ${AvatarRotation} infinite 1s linear;
         `


### PR DESCRIPTION
- no-unused-varsでアンスコから始まる変数を無視するように
- onTouchEndでflipしないように ... onClickと同時に着火してることがあるっぽくて共存するように対応する気にならん
- s-cにpropsをそのまんま与えているせいで生DOMに存在しないrotateという属性まで展開されているらしくて、それの解決をした
